### PR TITLE
Set _buildingWhere to false after adding where condition

### DIFF
--- a/lib/query-builder.js
+++ b/lib/query-builder.js
@@ -19,6 +19,7 @@ Query.prototype.where = function (field, val, opt) {
   this.query.push(prefix + field + ':');
 
   if (val) this.equals(val);
+  this._buildingWhere = false;
 
   return this;
 };
@@ -118,9 +119,9 @@ Query.prototype.between = function (start, end, method) {
 
 
 Query.prototype.betweenWithOpenIntervals = function (start, end, method) {
-  this._ensureIsBuildingWhere('between' || method);
+  this._ensureIsBuildingWhere('betweenWithOpenIntervals' || method);
 
-  if (arguments.length !== 2) throw new Error('method between() must receive 2 arguments');
+  if (arguments.length !== 2) throw new Error('method betweenWithOpenIntervals() must receive 2 arguments');
 
   if (!start) start = '*';
   if (!end) end = '*';


### PR DESCRIPTION
`_ensureIsBuildingWhere` was throwing if you called a method like `between` after a `where` call.
